### PR TITLE
GVim Desktop Entry Modifier Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # vimform7-builds
 Latest Vimform7 Distribution Archives
+
+The latest build adds a little more support for gvim. Is Spacemacs on the horizon? Only Chronos knows.
+
+2020-07-26:
+    Added a script, and updated the project-update function in the *open-prj* script, to modify the desktop entry for use with GVim, if the script is launched with the relatively undocumented -g flag.
+    Resetting the desktop entry to default if the *open-prj* script is subsequently launched without the -g flag is simple, but not implemented today.


### PR DESCRIPTION
The open-prj script will conditionally update the desktop entry to open gvim with the last opened project if the g flag is provided (likely the default on a new installation that has never used the f flag).